### PR TITLE
Fix Multi-file upload

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,1 @@
+Atle Wee Førre

--- a/src/Gren/Kernel/File.js
+++ b/src/Gren/Kernel/File.js
@@ -136,7 +136,12 @@ function _File_uploadOneOrMore(mimes)
 		_File_node.addEventListener('change', function(event)
 		{
 			var grenFiles = event.target.files;
-			callback(__Scheduler_succeed({ f : grenFiles.a, fs : grenFiles.b }));
+			var first = grenFiles[0];
+			var rest = [];
+			for (var i=1; i<grenFiles.length; i++) {
+				rest.push(grenFiles[i])
+			}
+			callback(__Scheduler_succeed({ f : first, fs : rest }));
 		});
 		_File_click(_File_node);
 	});


### PR DESCRIPTION
Using the multi-file select currently crashes. ( grenFiles.a/b is undefined ):
**Gren:**
![image](https://user-images.githubusercontent.com/11732817/171627257-5d4d24d5-391b-491a-9366-cd29f9053395.png)

 
_ 
 

The issue is that the function in elm turning the FileList (not array) into elmFiles.a and elmFiles.b is now removed.
**Elm:**
![image](https://user-images.githubusercontent.com/11732817/171626548-c59810e7-7ac6-45be-a1d6-cf71aadd109c.png)
This change fixes the issue. Tested locally with one and many files.